### PR TITLE
Test: github action 확인용 PR

### DIFF
--- a/.github/workflows/update-pr-description.yml
+++ b/.github/workflows/update-pr-description.yml
@@ -2,7 +2,7 @@ name: Update PR Description
 
 on:
   pull_request:
-    types: [opened, synchronize, edited]
+    types: [opened]
 
 permissions:
   contents: read
@@ -102,8 +102,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
-          # Prepare the new PR description
-          NEW_DESCRIPTION=$'## 🤖 자동 생성된 PR 정보\n\n'
+
+
           NEW_DESCRIPTION+=$'### 📦 변경된 패키지\n'
           if [ "${{ steps.changes.outputs.changed_packages }}" == "No packages detected" ]; then
             NEW_DESCRIPTION+=$'패키지 변경 없음\n'

--- a/.github/workflows/update-pr-description.yml
+++ b/.github/workflows/update-pr-description.yml
@@ -114,7 +114,7 @@ jobs:
           NEW_DESCRIPTION+=$(echo "${{ steps.changes.outputs.changed_files }}" | sed 's/^/- /' | sed 's/*/-/g')
 
           NEW_DESCRIPTION+=$'\n\n### 📝 커밋 내역\n'
-          NEW_DESCRIPTION+=$(echo "${{ steps.changes.outputs.commit_messages }}" | sed 's/^/- /' ')
+          NEW_DESCRIPTION+=$(echo "${{ steps.changes.outputs.commit_messages }}" | sed 's/^/- /')
 
           NEW_DESCRIPTION+=$'\n\n### 관련 이슈\n'
           NEW_DESCRIPTION+=$'아래 목록에서 이 PR과 관련된 이슈를 선택해주세요. 선택한 이슈는 자동으로 PR과 연결됩니다:\n\n'

--- a/.github/workflows/update-pr-description.yml
+++ b/.github/workflows/update-pr-description.yml
@@ -129,38 +129,71 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
+          set -x  # 디버그 모드 활성화
+
+          echo "Starting Link Issues to PR process for PR #$PR_NUMBER"
+
           # Check if the comment is on a PR
           if ! gh pr view $PR_NUMBER &> /dev/null; then
             echo "This is not a PR. Skipping."
             exit 0
           fi
 
+          echo "Successfully verified that this is a PR"
+
           # Get the current PR description
           PR_BODY=$(gh pr view $PR_NUMBER --json body -q .body)
+          echo "Current PR body length: ${#PR_BODY}"
 
           # Extract the issue section
           ISSUE_SECTION=$(echo "$PR_BODY" | sed -n '/^### 관련 이슈/,$p')
+          echo "Extracted issue section length: ${#ISSUE_SECTION}"
 
           # Find checked issues (now includes org/repo)
           CHECKED_ISSUES=$(echo "$ISSUE_SECTION" | grep -oP "(?<=- \[x\] )[a-zA-Z0-9-]+/[a-zA-Z0-9-]+#\d+")
+          echo "Checked issues:"
+          echo "$CHECKED_ISSUES"
 
           # Unlink previously linked issues
+          echo "Fetching currently linked issues..."
           CURRENT_LINKED_ISSUES=$(gh pr view $PR_NUMBER --json projectItems --jq '.projectItems[].content.title')
+          echo "Currently linked issues:"
+          echo "$CURRENT_LINKED_ISSUES"
+
           for ISSUE in $CURRENT_LINKED_ISSUES
           do
-            gh pr edit $PR_NUMBER --remove-project "$ISSUE"
-            echo "Unlinked issue $ISSUE from PR #$PR_NUMBER"
+            echo "Attempting to unlink issue $ISSUE from PR #$PR_NUMBER"
+            if gh pr edit $PR_NUMBER --remove-project "$ISSUE"; then
+              echo "Successfully unlinked issue $ISSUE from PR #$PR_NUMBER"
+            else
+              echo "Failed to unlink issue $ISSUE from PR #$PR_NUMBER"
+            fi
           done
 
           # Link newly checked issues to PR
           for ISSUE in $CHECKED_ISSUES
           do
-            gh pr edit $PR_NUMBER --add-project "$ISSUE"
-            echo "Linked issue $ISSUE to PR #$PR_NUMBER"
+            echo "Attempting to link issue $ISSUE to PR #$PR_NUMBER"
+            if gh pr edit $PR_NUMBER --add-project "$ISSUE"; then
+              echo "Successfully linked issue $ISSUE to PR #$PR_NUMBER"
+            else
+              echo "Failed to link issue $ISSUE to PR #$PR_NUMBER"
+            fi
           done
 
           # Update PR description to reflect linked issues
+          echo "Updating PR description to reflect linked issues"
           UPDATED_ISSUE_SECTION=$(echo "$ISSUE_SECTION" | sed -E "s/- \[x\] ([a-zA-Z0-9-]+\/[a-zA-Z0-9-]+#[0-9]+)/- [x] \1 (연결됨)/g")
           UPDATED_PR_BODY="${PR_BODY//$ISSUE_SECTION/$UPDATED_ISSUE_SECTION}"
 
-          gh pr edit $PR_NUMBER --body "$UPDATED_PR_BODY"
+          echo "Updated PR body length: ${#UPDATED_PR_BODY}"
+
+          if gh pr edit $PR_NUMBER --body "$UPDATED_PR_BODY"; then
+            echo "Successfully updated PR description"
+          else
+            echo "Failed to update PR description"
+            exit 1
+          fi
+
+          echo "Link Issues to PR process completed successfully"
+        shell: bash

--- a/.github/workflows/update-pr-description.yml
+++ b/.github/workflows/update-pr-description.yml
@@ -144,15 +144,25 @@ jobs:
           # Get the current PR description
           PR_BODY=$(gh pr view $PR_NUMBER --json body -q .body)
           echo "Current PR body length: ${#PR_BODY}"
+          echo "PR body content:"
+          echo "$PR_BODY"
 
           # Extract the issue section
           ISSUE_SECTION=$(echo "$PR_BODY" | sed -n '/^### 관련 이슈/,$p')
           echo "Extracted issue section length: ${#ISSUE_SECTION}"
+          echo "Issue section content:"
+          echo "$ISSUE_SECTION"
 
-          # Find checked issues (now includes org/repo)
-          CHECKED_ISSUES=$(echo "$ISSUE_SECTION" | grep -oP "(?<=- \[x\] )[a-zA-Z0-9-]+/[a-zA-Z0-9-]+#\d+")
+          # Find checked issues (now includes org/repo and handles both [x] and [X])
+          CHECKED_ISSUES=$(echo "$ISSUE_SECTION" | grep -oP '(?<=- \[[xX]\] )[a-zA-Z0-9-]+/[a-zA-Z0-9-]+#\d+')
           echo "Checked issues:"
           echo "$CHECKED_ISSUES"
+
+          # If no checked issues, exit
+          if [ -z "$CHECKED_ISSUES" ]; then
+            echo "No checked issues found. Exiting."
+            exit 0
+          fi
 
           # Unlink previously linked issues
           echo "Fetching currently linked issues..."
@@ -183,10 +193,12 @@ jobs:
 
           # Update PR description to reflect linked issues
           echo "Updating PR description to reflect linked issues"
-          UPDATED_ISSUE_SECTION=$(echo "$ISSUE_SECTION" | sed -E "s/- \[x\] ([a-zA-Z0-9-]+\/[a-zA-Z0-9-]+#[0-9]+)/- [x] \1 (연결됨)/g")
+          UPDATED_ISSUE_SECTION=$(echo "$ISSUE_SECTION" | sed -E "s/- \[[xX]\] ([a-zA-Z0-9-]+\/[a-zA-Z0-9-]+#[0-9]+)/- [x] \1 (연결됨)/g")
           UPDATED_PR_BODY="${PR_BODY//$ISSUE_SECTION/$UPDATED_ISSUE_SECTION}"
 
           echo "Updated PR body length: ${#UPDATED_PR_BODY}"
+          echo "Updated PR body content:"
+          echo "$UPDATED_PR_BODY"
 
           if gh pr edit $PR_NUMBER --body "$UPDATED_PR_BODY"; then
             echo "Successfully updated PR description"

--- a/.github/workflows/update-pr-description.yml
+++ b/.github/workflows/update-pr-description.yml
@@ -53,7 +53,8 @@ jobs:
           echo "$CHANGED_PACKAGES"
 
           # Get all commit messages
-          COMMIT_MESSAGES=$(git log --format="- %s%n%b" ${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }} | sed -e '/^$/d' -e '/^- $/d')
+          COMMIT_MESSAGES=$(git log --format="%s%n%b" ${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }} | sed -e '/^$/d')
+
           echo "Commit messages:"
           echo "$COMMIT_MESSAGES"
 

--- a/.github/workflows/update-pr-description.yml
+++ b/.github/workflows/update-pr-description.yml
@@ -20,8 +20,19 @@ jobs:
       - name: Get changed files, packages, and commits
         id: changes
         run: |
+          # Determine if this is a new PR or an update
+          if [ "${{ github.event.action }}" == "opened" ]; then
+            # For new PRs, get all changes
+            BASE_SHA=${{ github.event.pull_request.base.sha }}
+            HEAD_SHA=${{ github.event.pull_request.head.sha }}
+          else
+            # For updates, get only the new changes
+            BASE_SHA=${{ github.event.before }}
+            HEAD_SHA=${{ github.event.after }}
+          fi
+
           # Get changed files
-          CHANGED_FILES=$(git diff --name-only ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }} | sort)
+          CHANGED_FILES=$(git diff --name-only $BASE_SHA $HEAD_SHA | sort)
           echo "Changed files:"
           echo "$CHANGED_FILES"
 
@@ -36,24 +47,39 @@ jobs:
               dir=$(dirname "$dir")
             done
 
-              if [[ -f "./package.json" ]]; then
-                echo $(jq -r .name "./package.json")
-                return 0
-              fi
+            if [[ -f "./package.json" ]]; then
+              echo $(jq -r .name "./package.json")
+              return 0
+            fi
 
             echo "Unknown"
           }
 
           # Get package names
-          CHANGED_PACKAGES=$(echo "$CHANGED_FILES" | while read file; do find_package "$file"; done | sort | uniq)
+          if [ "${{ github.event.action }}" == "opened" ]; then
+            # For new PRs, get all changed packages
+            CHANGED_PACKAGES=$(echo "$CHANGED_FILES" | while read file; do find_package "$file"; done | sort | uniq)
+          else
+            # For updates, get only new changed packages
+            EXISTING_PACKAGES=$(gh pr view ${{ github.event.pull_request.number }} --json body -q '.body' | sed -n '/^### 📦 변경된 패키지/,/^###/p' | grep '^- ' | sed 's/^- //')
+            NEW_PACKAGES=$(echo "$CHANGED_FILES" | while read file; do find_package "$file"; done | sort | uniq)
+            CHANGED_PACKAGES=$(comm -23 <(echo "$NEW_PACKAGES" | sort) <(echo "$EXISTING_PACKAGES" | sort))
+          fi
+
           if [ -z "$CHANGED_PACKAGES" ]; then
-            CHANGED_PACKAGES="No packages detected"
+            CHANGED_PACKAGES="No new packages detected"
           fi
           echo "Changed packages:"
           echo "$CHANGED_PACKAGES"
 
-          # Get all commit messages
-          COMMIT_MESSAGES=$(git log --format="- %s%n%b" ${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }} | sed -e '/^$/d' -e '/^- $/d')
+          # Get commit messages
+          if [ "${{ github.event.action }}" == "opened" ]; then
+            # For new PRs, get all commit messages
+            COMMIT_MESSAGES=$(git log --format="- %s%n%b" $BASE_SHA..$HEAD_SHA | sed -e '/^$/d' -e '/^- $/d')
+          else
+            # For updates, get only new commit messages
+            COMMIT_MESSAGES=$(git log --format="- %s%n%b" $BASE_SHA..$HEAD_SHA | sed -e '/^$/d' -e '/^- $/d')
+          fi
 
           echo "Commit messages:"
           echo "$COMMIT_MESSAGES"
@@ -102,27 +128,56 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
-          # Prepare the new PR description
-          NEW_DESCRIPTION=$'## 🤖 자동 생성된 PR 정보\n\n'
-          NEW_DESCRIPTION+=$'### 📦 변경된 패키지\n'
-          if [ "${{ steps.changes.outputs.changed_packages }}" == "No packages detected" ]; then
-            NEW_DESCRIPTION+=$'패키지 변경 없음\n'
-          else
-            NEW_DESCRIPTION+=$(echo "${{ steps.changes.outputs.changed_packages }}" | sed 's/^/- /' | sed 's/*/-/g')
-          fi
+          # Get the current PR description
+           CURRENT_DESCRIPTION=$(gh pr view $PR_NUMBER --json body -q .body)
 
-          NEW_DESCRIPTION+=$'\n### 📄 변경된 파일\n'
-          NEW_DESCRIPTION+=$(echo "${{ steps.changes.outputs.changed_files }}" | sed 's/^/- /' | sed 's/*/-/g')
+           # Check if this is a new PR or an update
+           if [ "${{ github.event.action }}" == "opened" ]; then
+             # This is a new PR, create the initial description
+             NEW_DESCRIPTION=$'### 📦 변경된 패키지\n'
+             if [ "${{ steps.changes.outputs.changed_packages }}" == "No packages detected" ]; then
+               NEW_DESCRIPTION+=$'패키지 변경 없음\n'
+             else
+               NEW_DESCRIPTION+=$(echo "${{ steps.changes.outputs.changed_packages }}" | sed 's/^/- /' | sed 's/*/-/g')
+             fi
 
-          NEW_DESCRIPTION+=$'\n\n### 📝 커밋 내역\n'
-          NEW_DESCRIPTION+=$(echo "${{ steps.changes.outputs.commit_messages }}")
+             NEW_DESCRIPTION+=$'\n### 📄 변경된 파일\n'
+             NEW_DESCRIPTION+=$(echo "${{ steps.changes.outputs.changed_files }}" | sed 's/^/- /' | sed 's/*/-/g')
 
-          NEW_DESCRIPTION+=$'\n\n### 관련 이슈\n'
-          NEW_DESCRIPTION+=$'아래 목록에서 이 PR과 관련된 이슈를 선택해주세요. 선택한 이슈는 자동으로 PR과 연결됩니다:\n\n'
-          NEW_DESCRIPTION+=$(echo "${{ steps.open_issues.outputs.open_issues }}")
+             NEW_DESCRIPTION+=$'\n\n### 📝 커밋 내역\n'
+             NEW_DESCRIPTION+=$(echo "${{ steps.changes.outputs.commit_messages }}")
 
-          # Update the PR description
-          gh pr edit $PR_NUMBER --body "${NEW_DESCRIPTION}"
+             NEW_DESCRIPTION+=$'\n\n### 관련 이슈\n'
+             NEW_DESCRIPTION+=$'아래 목록에서 이 PR과 관련된 이슈를 선택해주세요. 선택한 이슈는 자동으로 PR과 연결됩니다:\n\n'
+             NEW_DESCRIPTION+=$(echo "${{ steps.open_issues.outputs.open_issues }}")
+           else
+             # This is an update to an existing PR
+             # Extract the existing sections
+             PACKAGES_SECTION=$(echo "$CURRENT_DESCRIPTION" | sed -n '/^### 📦 변경된 패키지/,/^###/p' | sed '$d')
+             FILES_SECTION=$(echo "$CURRENT_DESCRIPTION" | sed -n '/^### 📄 변경된 파일/,/^###/p' | sed '$d')
+             COMMITS_SECTION=$(echo "$CURRENT_DESCRIPTION" | sed -n '/^### 📝 커밋 내역/,/^###/p' | sed '$d')
+             ISSUES_SECTION=$(echo "$CURRENT_DESCRIPTION" | sed -n '/^### 관련 이슈/,$p')
+
+             # Update the packages section
+             if [ "${{ steps.changes.outputs.changed_packages }}" != "No packages detected" ]; then
+               PACKAGES_SECTION+=$'\n'
+               PACKAGES_SECTION+=$(echo "${{ steps.changes.outputs.changed_packages }}" | sed 's/^/- /' | sed 's/*/-/g')
+             fi
+
+             # Update the files section
+             FILES_SECTION+=$'\n'
+             FILES_SECTION+=$(echo "${{ steps.changes.outputs.changed_files }}" | sed 's/^/- /' | sed 's/*/-/g')
+
+             # Update the commits section
+             COMMITS_SECTION+=$'\n'
+             COMMITS_SECTION+=$(echo "${{ steps.changes.outputs.commit_messages }}")
+
+             # Combine the updated sections
+             NEW_DESCRIPTION="${PACKAGES_SECTION}\n\n${FILES_SECTION}\n\n${COMMITS_SECTION}\n\n${ISSUES_SECTION}"
+           fi
+
+           # Update the PR description
+           gh pr edit $PR_NUMBER --body "${NEW_DESCRIPTION}"
 
       - name: Link Issues to PR
         if: github.event.action == 'edited' && github.event.changes.body

--- a/.github/workflows/update-pr-description.yml
+++ b/.github/workflows/update-pr-description.yml
@@ -102,27 +102,42 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
-          # Prepare the new PR description
-          NEW_DESCRIPTION=$'## 🤖 자동 생성된 PR 정보\n\n'
-          NEW_DESCRIPTION+=$'### 📦 변경된 패키지\n'
+          # Get the current PR description
+          CURRENT_DESCRIPTION=$(gh pr view $PR_NUMBER --json body -q .body)
+
+          # Function to update a specific section
+          update_section() {
+            local section_name="$1"
+            local new_content="$2"
+            local section_pattern="### $section_name\n"
+            if [[ "$CURRENT_DESCRIPTION" == *"$section_pattern"* ]]; then
+              # If section exists, replace its content
+              CURRENT_DESCRIPTION=$(echo "$CURRENT_DESCRIPTION" | sed -e "/### $section_name/,/###/c\\### $section_name\n$new_content\n")
+            else
+              # If section doesn't exist, add it at the end
+              CURRENT_DESCRIPTION+=$"\n\n### $section_name\n$new_content"
+            fi
+          }
+
+          # Update changed packages section
+          PACKAGES_CONTENT=""
           if [ "${{ steps.changes.outputs.changed_packages }}" == "No packages detected" ]; then
-            NEW_DESCRIPTION+=$'패키지 변경 없음\n'
+            PACKAGES_CONTENT="패키지 변경 없음"
           else
-            NEW_DESCRIPTION+=$(echo "${{ steps.changes.outputs.changed_packages }}" | sed 's/^/- /' | sed 's/*/-/g')
+            PACKAGES_CONTENT=$(echo "${{ steps.changes.outputs.changed_packages }}" | sed 's/^/- /' | sed 's/*/-/g')
           fi
+          update_section "📦 변경된 패키지" "$PACKAGES_CONTENT"
 
-          NEW_DESCRIPTION+=$'\n### 📄 변경된 파일\n'
-          NEW_DESCRIPTION+=$(echo "${{ steps.changes.outputs.changed_files }}" | sed 's/^/- /' | sed 's/*/-/g')
+          # Update changed files section
+          FILES_CONTENT=$(echo "${{ steps.changes.outputs.changed_files }}" | sed 's/^/- /' | sed 's/*/-/g')
+          update_section "📄 변경된 파일" "$FILES_CONTENT"
 
-          NEW_DESCRIPTION+=$'\n\n### 📝 커밋 내역\n'
-          NEW_DESCRIPTION+=$(echo "${{ steps.changes.outputs.commit_messages }}")
-
-          NEW_DESCRIPTION+=$'\n\n### 관련 이슈\n'
-          NEW_DESCRIPTION+=$'아래 목록에서 이 PR과 관련된 이슈를 선택해주세요. 선택한 이슈는 자동으로 PR과 연결됩니다:\n\n'
-          NEW_DESCRIPTION+=$(echo "${{ steps.open_issues.outputs.open_issues }}")
+          # Update commit messages section
+          COMMIT_CONTENT=$(echo "${{ steps.changes.outputs.commit_messages }}")
+          update_section "📝 커밋 내역" "$COMMIT_CONTENT"
 
           # Update the PR description
-          gh pr edit $PR_NUMBER --body "${NEW_DESCRIPTION}"
+          gh pr edit $PR_NUMBER --body "${CURRENT_DESCRIPTION}"
 
       - name: Link Issues to PR
         if: github.event.action == 'edited' && github.event.changes.body

--- a/.github/workflows/update-pr-description.yml
+++ b/.github/workflows/update-pr-description.yml
@@ -3,8 +3,6 @@ name: Update PR Description
 on:
   pull_request:
     types: [opened, synchronize]
-  issue_comment:
-    types: [created, edited]
 
 permissions:
   contents: read
@@ -135,39 +133,26 @@ jobs:
           # Update the PR description
           gh pr edit $PR_NUMBER --body "${FULL_DESCRIPTION}"
 
-      - name: Link Issues to PR
-        if: github.event_name == 'issue_comment'
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR_NUMBER: ${{ github.event.issue.number }}
-          COMMENT_BODY: ${{ github.event.comment.body }}
-          ORG: "my-type-world-cup"
-          REPO: "my-type-world-cup-frontend"
-        run: |
-          # Check if the comment is on a PR
-          if ! gh pr view $PR_NUMBER &> /dev/null; then
-            echo "This comment is not on a PR. Skipping."
-            exit 0
-          fi
+          # Find checked issues and link them to the PR
+          CHECKED_ISSUES=$(echo "$FULL_DESCRIPTION" | sed -n '/^### 관련 이슈/,/^---/p' | grep -oP "(?<=- \[x\] $ORG/$REPO#)\d+")
 
-          # Get the current PR description
-          PR_BODY=$(gh pr view $PR_NUMBER --json body -q .body)
-
-          # Extract the issue section
-          ISSUE_SECTION=$(echo "$PR_BODY" | sed -n '/^### 관련 이슈/,/^---/p')
-
-          # Find checked issues
-          CHECKED_ISSUES=$(echo "$ISSUE_SECTION" | grep -oP "(?<=- \[x\] $ORG/$REPO#)\d+")
-
-          # Link issues to PR
           for ISSUE in $CHECKED_ISSUES
           do
             gh pr edit $PR_NUMBER --add-project "Issue #$ISSUE"
             echo "Linked issue #$ISSUE to PR #$PR_NUMBER"
+
+            # Update PR description to reflect linked issues
+            FULL_DESCRIPTION=$(echo "$FULL_DESCRIPTION" | sed "s/- \[x\] $ORG\/$REPO#$ISSUE/- [x] $ORG\/$REPO#$ISSUE (연결됨)/g")
           done
 
-          # Update PR description to reflect linked issues
-          UPDATED_ISSUE_SECTION=$(echo "$ISSUE_SECTION" | sed "s/- \[x\] $ORG\/$REPO#\($CHECKED_ISSUES\)/- [x] $ORG\/$REPO#\1 (연결됨)/g")
-          UPDATED_PR_BODY="${PR_BODY//$ISSUE_SECTION/$UPDATED_ISSUE_SECTION}"
+          # Update PR description again with linked issue status
+          gh pr edit $PR_NUMBER --body "$FULL_DESCRIPTION"
 
-          gh pr edit $PR_NUMBER --body "$UPDATED_PR_BODY"
+          # Remove links for unchecked issues
+          UNCHECKED_ISSUES=$(echo "$FULL_DESCRIPTION" | sed -n '/^### 관련 이슈/,/^---/p' | grep -oP "(?<=- \[ \] $ORG/$REPO#)\d+")
+
+          for ISSUE in $UNCHECKED_ISSUES
+          do
+            gh pr edit $PR_NUMBER --remove-project "Issue #$ISSUE"
+            echo "Removed link for issue #$ISSUE from PR #$PR_NUMBER"
+          done

--- a/.github/workflows/update-pr-description.yml
+++ b/.github/workflows/update-pr-description.yml
@@ -20,19 +20,8 @@ jobs:
       - name: Get changed files, packages, and commits
         id: changes
         run: |
-          # Determine if this is a new PR or an update
-          if [ "${{ github.event.action }}" == "opened" ]; then
-            # For new PRs, get all changes
-            BASE_SHA=${{ github.event.pull_request.base.sha }}
-            HEAD_SHA=${{ github.event.pull_request.head.sha }}
-          else
-            # For updates, get only the new changes
-            BASE_SHA=${{ github.event.before }}
-            HEAD_SHA=${{ github.event.after }}
-          fi
-
           # Get changed files
-          CHANGED_FILES=$(git diff --name-only $BASE_SHA $HEAD_SHA | sort)
+          CHANGED_FILES=$(git diff --name-only ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }} | sort)
           echo "Changed files:"
           echo "$CHANGED_FILES"
 
@@ -47,39 +36,24 @@ jobs:
               dir=$(dirname "$dir")
             done
 
-            if [[ -f "./package.json" ]]; then
-              echo $(jq -r .name "./package.json")
-              return 0
-            fi
+              if [[ -f "./package.json" ]]; then
+                echo $(jq -r .name "./package.json")
+                return 0
+              fi
 
             echo "Unknown"
           }
 
           # Get package names
-          if [ "${{ github.event.action }}" == "opened" ]; then
-            # For new PRs, get all changed packages
-            CHANGED_PACKAGES=$(echo "$CHANGED_FILES" | while read file; do find_package "$file"; done | sort | uniq)
-          else
-            # For updates, get only new changed packages
-            EXISTING_PACKAGES=$(gh pr view ${{ github.event.pull_request.number }} --json body -q '.body' | sed -n '/^### 📦 변경된 패키지/,/^###/p' | grep '^- ' | sed 's/^- //')
-            NEW_PACKAGES=$(echo "$CHANGED_FILES" | while read file; do find_package "$file"; done | sort | uniq)
-            CHANGED_PACKAGES=$(comm -23 <(echo "$NEW_PACKAGES" | sort) <(echo "$EXISTING_PACKAGES" | sort))
-          fi
-
+          CHANGED_PACKAGES=$(echo "$CHANGED_FILES" | while read file; do find_package "$file"; done | sort | uniq)
           if [ -z "$CHANGED_PACKAGES" ]; then
-            CHANGED_PACKAGES="No new packages detected"
+            CHANGED_PACKAGES="No packages detected"
           fi
           echo "Changed packages:"
           echo "$CHANGED_PACKAGES"
 
-          # Get commit messages
-          if [ "${{ github.event.action }}" == "opened" ]; then
-            # For new PRs, get all commit messages
-            COMMIT_MESSAGES=$(git log --format="- %s%n%b" $BASE_SHA..$HEAD_SHA | sed -e '/^$/d' -e '/^- $/d')
-          else
-            # For updates, get only new commit messages
-            COMMIT_MESSAGES=$(git log --format="- %s%n%b" $BASE_SHA..$HEAD_SHA | sed -e '/^$/d' -e '/^- $/d')
-          fi
+          # Get all commit messages
+          COMMIT_MESSAGES=$(git log --format="- %s%n%b" ${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }} | sed -e '/^$/d' -e '/^- $/d')
 
           echo "Commit messages:"
           echo "$COMMIT_MESSAGES"
@@ -128,56 +102,27 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
-          # Get the current PR description
-           CURRENT_DESCRIPTION=$(gh pr view $PR_NUMBER --json body -q .body)
+          # Prepare the new PR description
+          NEW_DESCRIPTION=$'## 🤖 자동 생성된 PR 정보\n\n'
+          NEW_DESCRIPTION+=$'### 📦 변경된 패키지\n'
+          if [ "${{ steps.changes.outputs.changed_packages }}" == "No packages detected" ]; then
+            NEW_DESCRIPTION+=$'패키지 변경 없음\n'
+          else
+            NEW_DESCRIPTION+=$(echo "${{ steps.changes.outputs.changed_packages }}" | sed 's/^/- /' | sed 's/*/-/g')
+          fi
 
-           # Check if this is a new PR or an update
-           if [ "${{ github.event.action }}" == "opened" ]; then
-             # This is a new PR, create the initial description
-             NEW_DESCRIPTION=$'### 📦 변경된 패키지\n'
-             if [ "${{ steps.changes.outputs.changed_packages }}" == "No packages detected" ]; then
-               NEW_DESCRIPTION+=$'패키지 변경 없음\n'
-             else
-               NEW_DESCRIPTION+=$(echo "${{ steps.changes.outputs.changed_packages }}" | sed 's/^/- /' | sed 's/*/-/g')
-             fi
+          NEW_DESCRIPTION+=$'\n### 📄 변경된 파일\n'
+          NEW_DESCRIPTION+=$(echo "${{ steps.changes.outputs.changed_files }}" | sed 's/^/- /' | sed 's/*/-/g')
 
-             NEW_DESCRIPTION+=$'\n### 📄 변경된 파일\n'
-             NEW_DESCRIPTION+=$(echo "${{ steps.changes.outputs.changed_files }}" | sed 's/^/- /' | sed 's/*/-/g')
+          NEW_DESCRIPTION+=$'\n\n### 📝 커밋 내역\n'
+          NEW_DESCRIPTION+=$(echo "${{ steps.changes.outputs.commit_messages }}")
 
-             NEW_DESCRIPTION+=$'\n\n### 📝 커밋 내역\n'
-             NEW_DESCRIPTION+=$(echo "${{ steps.changes.outputs.commit_messages }}")
+          NEW_DESCRIPTION+=$'\n\n### 관련 이슈\n'
+          NEW_DESCRIPTION+=$'아래 목록에서 이 PR과 관련된 이슈를 선택해주세요. 선택한 이슈는 자동으로 PR과 연결됩니다:\n\n'
+          NEW_DESCRIPTION+=$(echo "${{ steps.open_issues.outputs.open_issues }}")
 
-             NEW_DESCRIPTION+=$'\n\n### 관련 이슈\n'
-             NEW_DESCRIPTION+=$'아래 목록에서 이 PR과 관련된 이슈를 선택해주세요. 선택한 이슈는 자동으로 PR과 연결됩니다:\n\n'
-             NEW_DESCRIPTION+=$(echo "${{ steps.open_issues.outputs.open_issues }}")
-           else
-             # This is an update to an existing PR
-             # Extract the existing sections
-             PACKAGES_SECTION=$(echo "$CURRENT_DESCRIPTION" | sed -n '/^### 📦 변경된 패키지/,/^###/p' | sed '$d')
-             FILES_SECTION=$(echo "$CURRENT_DESCRIPTION" | sed -n '/^### 📄 변경된 파일/,/^###/p' | sed '$d')
-             COMMITS_SECTION=$(echo "$CURRENT_DESCRIPTION" | sed -n '/^### 📝 커밋 내역/,/^###/p' | sed '$d')
-             ISSUES_SECTION=$(echo "$CURRENT_DESCRIPTION" | sed -n '/^### 관련 이슈/,$p')
-
-             # Update the packages section
-             if [ "${{ steps.changes.outputs.changed_packages }}" != "No packages detected" ]; then
-               PACKAGES_SECTION+=$'\n'
-               PACKAGES_SECTION+=$(echo "${{ steps.changes.outputs.changed_packages }}" | sed 's/^/- /' | sed 's/*/-/g')
-             fi
-
-             # Update the files section
-             FILES_SECTION+=$'\n'
-             FILES_SECTION+=$(echo "${{ steps.changes.outputs.changed_files }}" | sed 's/^/- /' | sed 's/*/-/g')
-
-             # Update the commits section
-             COMMITS_SECTION+=$'\n'
-             COMMITS_SECTION+=$(echo "${{ steps.changes.outputs.commit_messages }}")
-
-             # Combine the updated sections
-             NEW_DESCRIPTION="${PACKAGES_SECTION}\n\n${FILES_SECTION}\n\n${COMMITS_SECTION}\n\n${ISSUES_SECTION}"
-           fi
-
-           # Update the PR description
-           gh pr edit $PR_NUMBER --body "${NEW_DESCRIPTION}"
+          # Update the PR description
+          gh pr edit $PR_NUMBER --body "${NEW_DESCRIPTION}"
 
       - name: Link Issues to PR
         if: github.event.action == 'edited' && github.event.changes.body

--- a/.github/workflows/update-pr-description.yml
+++ b/.github/workflows/update-pr-description.yml
@@ -102,42 +102,27 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
-          # Get the current PR description
-          CURRENT_DESCRIPTION=$(gh pr view $PR_NUMBER --json body -q .body)
-
-          # Function to update a specific section
-          update_section() {
-            local section_name="$1"
-            local new_content="$2"
-            local section_pattern="### $section_name\n"
-            if [[ "$CURRENT_DESCRIPTION" == *"$section_pattern"* ]]; then
-              # If section exists, replace its content
-              CURRENT_DESCRIPTION=$(echo "$CURRENT_DESCRIPTION" | sed -e "/### $section_name/,/###/c\\### $section_name\n$new_content\n")
-            else
-              # If section doesn't exist, add it at the end
-              CURRENT_DESCRIPTION+=$"\n\n### $section_name\n$new_content"
-            fi
-          }
-
-          # Update changed packages section
-          PACKAGES_CONTENT=""
+          # Prepare the new PR description
+          NEW_DESCRIPTION=$'## 🤖 자동 생성된 PR 정보\n\n'
+          NEW_DESCRIPTION+=$'### 📦 변경된 패키지\n'
           if [ "${{ steps.changes.outputs.changed_packages }}" == "No packages detected" ]; then
-            PACKAGES_CONTENT="패키지 변경 없음"
+            NEW_DESCRIPTION+=$'패키지 변경 없음\n'
           else
-            PACKAGES_CONTENT=$(echo "${{ steps.changes.outputs.changed_packages }}" | sed 's/^/- /' | sed 's/*/-/g')
+            NEW_DESCRIPTION+=$(echo "${{ steps.changes.outputs.changed_packages }}" | sed 's/^/- /' | sed 's/*/-/g')
           fi
-          update_section "📦 변경된 패키지" "$PACKAGES_CONTENT"
 
-          # Update changed files section
-          FILES_CONTENT=$(echo "${{ steps.changes.outputs.changed_files }}" | sed 's/^/- /' | sed 's/*/-/g')
-          update_section "📄 변경된 파일" "$FILES_CONTENT"
+          NEW_DESCRIPTION+=$'\n### 📄 변경된 파일\n'
+          NEW_DESCRIPTION+=$(echo "${{ steps.changes.outputs.changed_files }}" | sed 's/^/- /' | sed 's/*/-/g')
 
-          # Update commit messages section
-          COMMIT_CONTENT=$(echo "${{ steps.changes.outputs.commit_messages }}")
-          update_section "📝 커밋 내역" "$COMMIT_CONTENT"
+          NEW_DESCRIPTION+=$'\n\n### 📝 커밋 내역\n'
+          NEW_DESCRIPTION+=$(echo "${{ steps.changes.outputs.commit_messages }}")
+
+          NEW_DESCRIPTION+=$'\n\n### 관련 이슈\n'
+          NEW_DESCRIPTION+=$'아래 목록에서 이 PR과 관련된 이슈를 선택해주세요. 선택한 이슈는 자동으로 PR과 연결됩니다:\n\n'
+          NEW_DESCRIPTION+=$(echo "${{ steps.open_issues.outputs.open_issues }}")
 
           # Update the PR description
-          gh pr edit $PR_NUMBER --body "${CURRENT_DESCRIPTION}"
+          gh pr edit $PR_NUMBER --body "${NEW_DESCRIPTION}"
 
       - name: Link Issues to PR
         if: github.event.action == 'edited' && github.event.changes.body

--- a/.github/workflows/update-pr-description.yml
+++ b/.github/workflows/update-pr-description.yml
@@ -53,7 +53,7 @@ jobs:
           echo "$CHANGED_PACKAGES"
 
           # Get all commit messages
-          COMMIT_MESSAGES=$(git log --format="%s%n%b" ${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }} | sed -e '/^$/d')
+          COMMIT_MESSAGES=$(git log --format="- %s%n%b" ${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }} | sed -e '/^$/d' -e '/^- $/d')
 
           echo "Commit messages:"
           echo "$COMMIT_MESSAGES"
@@ -115,7 +115,7 @@ jobs:
           NEW_DESCRIPTION+=$(echo "${{ steps.changes.outputs.changed_files }}" | sed 's/^/- /' | sed 's/*/-/g')
 
           NEW_DESCRIPTION+=$'\n\n### 📝 커밋 내역\n'
-          NEW_DESCRIPTION+=$(echo "${{ steps.changes.outputs.commit_messages }}" | sed 's/^/- /')
+          NEW_DESCRIPTION+=$(echo "${{ steps.changes.outputs.commit_messages }}")
 
           NEW_DESCRIPTION+=$'\n\n### 관련 이슈\n'
           NEW_DESCRIPTION+=$'아래 목록에서 이 PR과 관련된 이슈를 선택해주세요. 선택한 이슈는 자동으로 PR과 연결됩니다:\n\n'

--- a/.github/workflows/update-pr-description.yml
+++ b/.github/workflows/update-pr-description.yml
@@ -118,7 +118,7 @@ jobs:
           NEW_DESCRIPTION+=$(echo "${{ steps.changes.outputs.commit_messages }}" | sed 's/^/- /' | sed 's/^- - /- /')
 
           NEW_DESCRIPTION+=$'\n\n### 관련 이슈\n'
-          NEW_DESCRIPTION+=$'아래 목록에서 이 PR과 관련된 이슈를 선택해주세요. 선택한 이슈는 자동으로 할당됩니다:\n\n'
+          NEW_DESCRIPTION+=$'아래 목록에서 이 PR과 관련된 이슈를 선택해주세요. 선택한 이슈는 자동으로 PR과 연결됩니다:\n\n'
           NEW_DESCRIPTION+=$(echo "${{ steps.open_issues.outputs.open_issues }}")
 
           NEW_DESCRIPTION+=$'\n\n---\n\n'
@@ -135,7 +135,7 @@ jobs:
           # Update the PR description
           gh pr edit $PR_NUMBER --body "${FULL_DESCRIPTION}"
 
-      - name: Check and Assign Issues
+      - name: Link Issues to PR
         if: github.event_name == 'issue_comment'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -159,18 +159,15 @@ jobs:
           # Find checked issues
           CHECKED_ISSUES=$(echo "$ISSUE_SECTION" | grep -oP "(?<=- \[x\] $ORG/$REPO#)\d+")
 
-          # Get PR author
-          PR_AUTHOR=$(gh pr view $PR_NUMBER --json author -q .author.login)
-
-          # Assign issues
+          # Link issues to PR
           for ISSUE in $CHECKED_ISSUES
           do
-            gh issue edit $ISSUE --add-assignee $PR_AUTHOR
-            echo "Assigned issue #$ISSUE to $PR_AUTHOR"
+            gh pr edit $PR_NUMBER --add-project "Issue #$ISSUE"
+            echo "Linked issue #$ISSUE to PR #$PR_NUMBER"
           done
 
-          # Update PR description to reflect assigned issues
-          UPDATED_ISSUE_SECTION=$(echo "$ISSUE_SECTION" | sed "s/- \[x\] $ORG\/$REPO#\($CHECKED_ISSUES\)/- [x] $ORG\/$REPO#\1 (할당됨)/g")
+          # Update PR description to reflect linked issues
+          UPDATED_ISSUE_SECTION=$(echo "$ISSUE_SECTION" | sed "s/- \[x\] $ORG\/$REPO#\($CHECKED_ISSUES\)/- [x] $ORG\/$REPO#\1 (연결됨)/g")
           UPDATED_PR_BODY="${PR_BODY//$ISSUE_SECTION/$UPDATED_ISSUE_SECTION}"
 
           gh pr edit $PR_NUMBER --body "$UPDATED_PR_BODY"

--- a/.github/workflows/update-pr-description.yml
+++ b/.github/workflows/update-pr-description.yml
@@ -2,9 +2,7 @@ name: Update PR Description
 
 on:
   pull_request:
-    types: [opened, synchronize]
-  issue_comment:
-    types: [created, edited]
+    types: [opened, synchronize, edited]
 
 permissions:
   contents: read

--- a/.github/workflows/update-pr-description.yml
+++ b/.github/workflows/update-pr-description.yml
@@ -96,11 +96,19 @@ jobs:
           echo "$OPEN_ISSUES" >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
 
-      - name: Update PR Description
+      - name: Update PR Description and Link Issues
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
+          ORG: "my-type-world-cup"
+          REPO: "my-type-world-cup-frontend"
         run: |
+          # Get the current PR description
+          CURRENT_DESCRIPTION=$(gh pr view $PR_NUMBER --json body -q .body)
+
+          # Extract the current issue section
+          CURRENT_ISSUE_SECTION=$(echo "$CURRENT_DESCRIPTION" | sed -n '/^### 관련 이슈/,/^---/p')
+
           # Prepare the new PR description
           NEW_DESCRIPTION=$'## 🤖 자동 생성된 PR 정보\n\n'
           NEW_DESCRIPTION+=$'### 📦 변경된 패키지\n'
@@ -118,12 +126,17 @@ jobs:
 
           NEW_DESCRIPTION+=$'\n\n### 관련 이슈\n'
           NEW_DESCRIPTION+=$'아래 목록에서 이 PR과 관련된 이슈를 선택해주세요. 선택한 이슈는 자동으로 PR과 연결됩니다:\n\n'
-          NEW_DESCRIPTION+=$(echo "${{ steps.open_issues.outputs.open_issues }}")
 
-          NEW_DESCRIPTION+=$'\n\n---\n\n'
+          # Process open issues and preserve checked state
+          while IFS='|' read -r issue_number issue_title; do
+            if echo "$CURRENT_ISSUE_SECTION" | grep -q "\[x\] $ORG/$REPO#$issue_number"; then
+              NEW_DESCRIPTION+="- [x] $ORG/$REPO#$issue_number $issue_title\n"
+            else
+              NEW_DESCRIPTION+="- [ ] $ORG/$REPO#$issue_number $issue_title\n"
+            fi
+          done <<< "${{ steps.open_issues.outputs.open_issues }}"
 
-          # Get the current PR description
-          CURRENT_DESCRIPTION=$(gh pr view $PR_NUMBER --json body -q .body)
+          NEW_DESCRIPTION+=$'\n---\n\n'
 
           # Extract the manual part of the description (everything after the auto-generated part)
           MANUAL_DESCRIPTION=$(echo "$CURRENT_DESCRIPTION" | sed -n '/^---$/,$p' | tail -n +2)
@@ -134,29 +147,11 @@ jobs:
           # Update the PR description
           gh pr edit $PR_NUMBER --body "${FULL_DESCRIPTION}"
 
-      - name: Link Issues to PR
-        if: github.event_name == 'issue_comment'
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR_NUMBER: ${{ github.event.issue.number }}
-          COMMENT_BODY: ${{ github.event.comment.body }}
-          ORG: "my-type-world-cup"
-          REPO: "my-type-world-cup-frontend"
-        run: |
-          # Check if the comment is on a PR
-          if ! gh pr view $PR_NUMBER &> /dev/null; then
-            echo "This comment is not on a PR. Skipping."
-            exit 0
-          fi
-
-          # Get the current PR description
-          PR_BODY=$(gh pr view $PR_NUMBER --json body -q .body)
-
-          # Extract the issue section
-          ISSUE_SECTION=$(echo "$PR_BODY" | sed -n '/^### 관련 이슈/,/^---/p')
+          # Extract the updated issue section
+          UPDATED_ISSUE_SECTION=$(echo "$FULL_DESCRIPTION" | sed -n '/^### 관련 이슈/,/^---/p')
 
           # Find checked issues
-          CHECKED_ISSUES=$(echo "$ISSUE_SECTION" | grep -oP "(?<=- \[x\] $ORG/$REPO#)\d+")
+          CHECKED_ISSUES=$(echo "$UPDATED_ISSUE_SECTION" | grep -oP "(?<=- \[x\] $ORG/$REPO#)\d+")
 
           # Unlink previously linked issues
           CURRENT_LINKED_ISSUES=$(gh pr view $PR_NUMBER --json projectItems --jq '.projectItems[].content.number')
@@ -174,7 +169,7 @@ jobs:
           done
 
           # Update PR description to reflect linked issues
-          UPDATED_ISSUE_SECTION=$(echo "$ISSUE_SECTION" | sed "s/- \[x\] $ORG\/$REPO#\($CHECKED_ISSUES\)/- [x] $ORG\/$REPO#\1 (연결됨)/g")
-          UPDATED_PR_BODY="${PR_BODY//$ISSUE_SECTION/$UPDATED_ISSUE_SECTION}"
+          FINAL_ISSUE_SECTION=$(echo "$UPDATED_ISSUE_SECTION" | sed "s/- \[x\] $ORG\/$REPO#\($CHECKED_ISSUES\)/- [x] $ORG\/$REPO#\1 (연결됨)/g")
+          FINAL_PR_BODY="${FULL_DESCRIPTION//$UPDATED_ISSUE_SECTION/$FINAL_ISSUE_SECTION}"
 
-          gh pr edit $PR_NUMBER --body "$UPDATED_PR_BODY"
+          gh pr edit $PR_NUMBER --body "$FINAL_PR_BODY"

--- a/.github/workflows/update-pr-description.yml
+++ b/.github/workflows/update-pr-description.yml
@@ -3,6 +3,8 @@ name: Update PR Description
 on:
   pull_request:
     types: [opened, synchronize]
+  issue_comment:
+    types: [created, edited]
 
 permissions:
   contents: read
@@ -70,17 +72,18 @@ jobs:
           echo "$COMMIT_MESSAGES" >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
 
-      - name: Fetch Open Issues
+      - name: Fetch Open Issues for PR Creator
         id: open_issues
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ORG: "my-type-world-cup"
           REPO: "my-type-world-cup-frontend"
         run: |
+          PR_CREATOR=$(gh pr view ${{ github.event.pull_request.number }} --json author --jq .author.login)
           OPEN_ISSUES=$(gh api graphql -f query='
-            query($org: String!, $repo: String!) {
+            query($org: String!, $repo: String!, $creator: String!) {
               repository(owner: $org, name: $repo) {
-                issues(states: OPEN, first: 20) {
+                issues(states: OPEN, first: 20, filterBy: {assignee: $creator}) {
                   nodes {
                     number
                     title
@@ -89,7 +92,7 @@ jobs:
                 }
               }
             }
-          ' -F org=$ORG -F repo=$REPO --jq '.data.repository.issues.nodes[] | "- [ ] \(env.ORG)/\(env.REPO)#\(.number) \(.title)"')
+          ' -F org=$ORG -F repo=$REPO -F creator=$PR_CREATOR --jq '.data.repository.issues.nodes[] | "- [ ] \(env.ORG)/\(env.REPO)#\(.number) \(.title)"')
 
           echo "open_issues<<EOF" >> $GITHUB_OUTPUT
           echo "$OPEN_ISSUES" >> $GITHUB_OUTPUT
@@ -133,26 +136,47 @@ jobs:
           # Update the PR description
           gh pr edit $PR_NUMBER --body "${FULL_DESCRIPTION}"
 
-          # Find checked issues and link them to the PR
-          CHECKED_ISSUES=$(echo "$FULL_DESCRIPTION" | sed -n '/^### 관련 이슈/,/^---/p' | grep -oP "(?<=- \[x\] $ORG/$REPO#)\d+")
+      - name: Link Issues to PR
+        if: github.event_name == 'issue_comment'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.issue.number }}
+          COMMENT_BODY: ${{ github.event.comment.body }}
+          ORG: "my-type-world-cup"
+          REPO: "my-type-world-cup-frontend"
+        run: |
+          # Check if the comment is on a PR
+          if ! gh pr view $PR_NUMBER &> /dev/null; then
+            echo "This comment is not on a PR. Skipping."
+            exit 0
+          fi
 
+          # Get the current PR description
+          PR_BODY=$(gh pr view $PR_NUMBER --json body -q .body)
+
+          # Extract the issue section
+          ISSUE_SECTION=$(echo "$PR_BODY" | sed -n '/^### 관련 이슈/,/^---/p')
+
+          # Find checked issues
+          CHECKED_ISSUES=$(echo "$ISSUE_SECTION" | grep -oP "(?<=- \[x\] $ORG/$REPO#)\d+")
+
+          # Unlink previously linked issues
+          CURRENT_LINKED_ISSUES=$(gh pr view $PR_NUMBER --json projectItems --jq '.projectItems[].content.number')
+          for ISSUE in $CURRENT_LINKED_ISSUES
+          do
+            gh pr edit $PR_NUMBER --remove-project "Issue #$ISSUE"
+            echo "Unlinked issue #$ISSUE from PR #$PR_NUMBER"
+          done
+
+          # Link newly checked issues to PR
           for ISSUE in $CHECKED_ISSUES
           do
             gh pr edit $PR_NUMBER --add-project "Issue #$ISSUE"
             echo "Linked issue #$ISSUE to PR #$PR_NUMBER"
-
-            # Update PR description to reflect linked issues
-            FULL_DESCRIPTION=$(echo "$FULL_DESCRIPTION" | sed "s/- \[x\] $ORG\/$REPO#$ISSUE/- [x] $ORG\/$REPO#$ISSUE (연결됨)/g")
           done
 
-          # Update PR description again with linked issue status
-          gh pr edit $PR_NUMBER --body "$FULL_DESCRIPTION"
+          # Update PR description to reflect linked issues
+          UPDATED_ISSUE_SECTION=$(echo "$ISSUE_SECTION" | sed "s/- \[x\] $ORG\/$REPO#\($CHECKED_ISSUES\)/- [x] $ORG\/$REPO#\1 (연결됨)/g")
+          UPDATED_PR_BODY="${PR_BODY//$ISSUE_SECTION/$UPDATED_ISSUE_SECTION}"
 
-          # Remove links for unchecked issues
-          UNCHECKED_ISSUES=$(echo "$FULL_DESCRIPTION" | sed -n '/^### 관련 이슈/,/^---/p' | grep -oP "(?<=- \[ \] $ORG/$REPO#)\d+")
-
-          for ISSUE in $UNCHECKED_ISSUES
-          do
-            gh pr edit $PR_NUMBER --remove-project "Issue #$ISSUE"
-            echo "Removed link for issue #$ISSUE from PR #$PR_NUMBER"
-          done
+          gh pr edit $PR_NUMBER --body "$UPDATED_PR_BODY"

--- a/.github/workflows/update-pr-description.yml
+++ b/.github/workflows/update-pr-description.yml
@@ -96,19 +96,11 @@ jobs:
           echo "$OPEN_ISSUES" >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
 
-      - name: Update PR Description and Link Issues
+      - name: Update PR Description
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
-          ORG: "my-type-world-cup"
-          REPO: "my-type-world-cup-frontend"
         run: |
-          # Get the current PR description
-          CURRENT_DESCRIPTION=$(gh pr view $PR_NUMBER --json body -q .body)
-
-          # Extract the current issue section
-          CURRENT_ISSUE_SECTION=$(echo "$CURRENT_DESCRIPTION" | sed -n '/^### 관련 이슈/,/^---/p')
-
           # Prepare the new PR description
           NEW_DESCRIPTION=$'## 🤖 자동 생성된 PR 정보\n\n'
           NEW_DESCRIPTION+=$'### 📦 변경된 패키지\n'
@@ -126,17 +118,12 @@ jobs:
 
           NEW_DESCRIPTION+=$'\n\n### 관련 이슈\n'
           NEW_DESCRIPTION+=$'아래 목록에서 이 PR과 관련된 이슈를 선택해주세요. 선택한 이슈는 자동으로 PR과 연결됩니다:\n\n'
+          NEW_DESCRIPTION+=$(echo "${{ steps.open_issues.outputs.open_issues }}")
 
-          # Process open issues and preserve checked state
-          while IFS='|' read -r issue_number issue_title; do
-            if echo "$CURRENT_ISSUE_SECTION" | grep -q "\[x\] $ORG/$REPO#$issue_number"; then
-              NEW_DESCRIPTION+="- [x] $ORG/$REPO#$issue_number $issue_title\n"
-            else
-              NEW_DESCRIPTION+="- [ ] $ORG/$REPO#$issue_number $issue_title\n"
-            fi
-          done <<< "${{ steps.open_issues.outputs.open_issues }}"
+          NEW_DESCRIPTION+=$'\n\n---\n\n'
 
-          NEW_DESCRIPTION+=$'\n---\n\n'
+          # Get the current PR description
+          CURRENT_DESCRIPTION=$(gh pr view $PR_NUMBER --json body -q .body)
 
           # Extract the manual part of the description (everything after the auto-generated part)
           MANUAL_DESCRIPTION=$(echo "$CURRENT_DESCRIPTION" | sed -n '/^---$/,$p' | tail -n +2)
@@ -147,11 +134,29 @@ jobs:
           # Update the PR description
           gh pr edit $PR_NUMBER --body "${FULL_DESCRIPTION}"
 
-          # Extract the updated issue section
-          UPDATED_ISSUE_SECTION=$(echo "$FULL_DESCRIPTION" | sed -n '/^### 관련 이슈/,/^---/p')
+      - name: Link Issues to PR
+        if: github.event_name == 'issue_comment'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.issue.number }}
+          COMMENT_BODY: ${{ github.event.comment.body }}
+          ORG: "my-type-world-cup"
+          REPO: "my-type-world-cup-frontend"
+        run: |
+          # Check if the comment is on a PR
+          if ! gh pr view $PR_NUMBER &> /dev/null; then
+            echo "This comment is not on a PR. Skipping."
+            exit 0
+          fi
+
+          # Get the current PR description
+          PR_BODY=$(gh pr view $PR_NUMBER --json body -q .body)
+
+          # Extract the issue section
+          ISSUE_SECTION=$(echo "$PR_BODY" | sed -n '/^### 관련 이슈/,/^---/p')
 
           # Find checked issues
-          CHECKED_ISSUES=$(echo "$UPDATED_ISSUE_SECTION" | grep -oP "(?<=- \[x\] $ORG/$REPO#)\d+")
+          CHECKED_ISSUES=$(echo "$ISSUE_SECTION" | grep -oP "(?<=- \[x\] $ORG/$REPO#)\d+")
 
           # Unlink previously linked issues
           CURRENT_LINKED_ISSUES=$(gh pr view $PR_NUMBER --json projectItems --jq '.projectItems[].content.number')
@@ -169,7 +174,7 @@ jobs:
           done
 
           # Update PR description to reflect linked issues
-          FINAL_ISSUE_SECTION=$(echo "$UPDATED_ISSUE_SECTION" | sed "s/- \[x\] $ORG\/$REPO#\($CHECKED_ISSUES\)/- [x] $ORG\/$REPO#\1 (연결됨)/g")
-          FINAL_PR_BODY="${FULL_DESCRIPTION//$UPDATED_ISSUE_SECTION/$FINAL_ISSUE_SECTION}"
+          UPDATED_ISSUE_SECTION=$(echo "$ISSUE_SECTION" | sed "s/- \[x\] $ORG\/$REPO#\($CHECKED_ISSUES\)/- [x] $ORG\/$REPO#\1 (연결됨)/g")
+          UPDATED_PR_BODY="${PR_BODY//$ISSUE_SECTION/$UPDATED_ISSUE_SECTION}"
 
-          gh pr edit $PR_NUMBER --body "$FINAL_PR_BODY"
+          gh pr edit $PR_NUMBER --body "$UPDATED_PR_BODY"

--- a/.github/workflows/update-pr-description.yml
+++ b/.github/workflows/update-pr-description.yml
@@ -130,7 +130,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
-          set -x  # 디버그 모드 활성화
 
           echo "Starting Link Issues to PR process for PR #$PR_NUMBER"
 
@@ -140,13 +139,9 @@ jobs:
             exit 0
           fi
 
-          echo "Successfully verified that this is a PR"
 
           # Get the current PR description
           PR_BODY=$(gh pr view $PR_NUMBER --json body -q .body)
-          echo "Current PR body length: ${#PR_BODY}"
-          echo "PR body content:"
-          echo "$PR_BODY"
 
           # Extract the issue section
           ISSUE_SECTION=$(echo "$PR_BODY" | sed -n '/^### 관련 이슈/,$p')
@@ -155,7 +150,7 @@ jobs:
           echo "$ISSUE_SECTION"
 
           # Find checked issues (now includes org/repo and handles both [x] and [X])
-          CHECKED_ISSUES=$(echo "$ISSUE_SECTION" | grep -oP '(?<=- \[[xX]\] )[a-zA-Z0-9-]+/[a-zA-Z0-9-]+#\d+')
+          CHECKED_ISSUES=$(echo "$ISSUE_SECTION" | grep -oP '(?<=- \[[xX]\] )[a-zA-Z0-9-]+/[a-zA-Z0-9-]+#\d+' || true)
           echo "Checked issues:"
           echo "$CHECKED_ISSUES"
 

--- a/.github/workflows/update-pr-description.yml
+++ b/.github/workflows/update-pr-description.yml
@@ -151,13 +151,13 @@ jobs:
 
           # Find checked issues (now includes org/repo and handles both [x] and [X])
           CHECKED_ISSUES=$(echo "$ISSUE_SECTION" | grep -oP '(?<=- \[[xX]\] )[a-zA-Z0-9-]+/[a-zA-Z0-9-]+#\d+' || true)
-          echo "Checked issues:"
-          echo "$CHECKED_ISSUES"
-
-          # If no checked issues, exit
+          echo -n "Checked issues: "
           if [ -z "$CHECKED_ISSUES" ]; then
+            echo "none"
             echo "No checked issues found. Exiting."
             exit 0
+          else
+            echo "$CHECKED_ISSUES"
           fi
 
           # Unlink previously linked issues

--- a/.github/workflows/update-pr-description.yml
+++ b/.github/workflows/update-pr-description.yml
@@ -21,7 +21,7 @@ jobs:
         id: changes
         run: |
           # Get changed files
-          CHANGED_FILES=$(git diff --name-only ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }} | sort | uniq)
+          CHANGED_FILES=$(git diff --name-only ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }} | sort)
           echo "Changed files:"
           echo "$CHANGED_FILES"
 
@@ -53,7 +53,7 @@ jobs:
           echo "$CHANGED_PACKAGES"
 
           # Get all commit messages
-          COMMIT_MESSAGES=$(git log --format="- %s%n%b" ${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }} | sed '/./s/^$//' | sed -e '/^$/d' -e '/^- $/d')
+          COMMIT_MESSAGES=$(git log --format="- %s%n%b" ${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }} | sed -e '/^$/d' -e '/^- $/d')
           echo "Commit messages:"
           echo "$COMMIT_MESSAGES"
 
@@ -114,38 +114,24 @@ jobs:
           NEW_DESCRIPTION+=$(echo "${{ steps.changes.outputs.changed_files }}" | sed 's/^/- /' | sed 's/*/-/g')
 
           NEW_DESCRIPTION+=$'\n\n### 📝 커밋 내역\n'
-          NEW_DESCRIPTION+=$(echo "${{ steps.changes.outputs.commit_messages }}" | sed 's/^/- /' | sed 's/^- - /- /')
+          NEW_DESCRIPTION+=$(echo "${{ steps.changes.outputs.commit_messages }}" | sed 's/^/- /' ')
 
           NEW_DESCRIPTION+=$'\n\n### 관련 이슈\n'
           NEW_DESCRIPTION+=$'아래 목록에서 이 PR과 관련된 이슈를 선택해주세요. 선택한 이슈는 자동으로 PR과 연결됩니다:\n\n'
           NEW_DESCRIPTION+=$(echo "${{ steps.open_issues.outputs.open_issues }}")
 
-          NEW_DESCRIPTION+=$'\n\n---\n\n'
-
-          # Get the current PR description
-          CURRENT_DESCRIPTION=$(gh pr view $PR_NUMBER --json body -q .body)
-
-          # Extract the manual part of the description (everything after the auto-generated part)
-          MANUAL_DESCRIPTION=$(echo "$CURRENT_DESCRIPTION" | sed -n '/^---$/,$p' | tail -n +2)
-
-          # Combine the new auto-generated part with the manual part
-          FULL_DESCRIPTION="${NEW_DESCRIPTION}${MANUAL_DESCRIPTION}"
-
           # Update the PR description
-          gh pr edit $PR_NUMBER --body "${FULL_DESCRIPTION}"
+          gh pr edit $PR_NUMBER --body "${NEW_DESCRIPTION}"
 
       - name: Link Issues to PR
-        if: github.event_name == 'issue_comment'
+        if: github.event.action == 'edited' && github.event.changes.body
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR_NUMBER: ${{ github.event.issue.number }}
-          COMMENT_BODY: ${{ github.event.comment.body }}
-          ORG: "my-type-world-cup"
-          REPO: "my-type-world-cup-frontend"
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           # Check if the comment is on a PR
           if ! gh pr view $PR_NUMBER &> /dev/null; then
-            echo "This comment is not on a PR. Skipping."
+            echo "This is not a PR. Skipping."
             exit 0
           fi
 
@@ -153,28 +139,28 @@ jobs:
           PR_BODY=$(gh pr view $PR_NUMBER --json body -q .body)
 
           # Extract the issue section
-          ISSUE_SECTION=$(echo "$PR_BODY" | sed -n '/^### 관련 이슈/,/^---/p')
+          ISSUE_SECTION=$(echo "$PR_BODY" | sed -n '/^### 관련 이슈/,$p')
 
-          # Find checked issues
-          CHECKED_ISSUES=$(echo "$ISSUE_SECTION" | grep -oP "(?<=- \[x\] $ORG/$REPO#)\d+")
+          # Find checked issues (now includes org/repo)
+          CHECKED_ISSUES=$(echo "$ISSUE_SECTION" | grep -oP "(?<=- \[x\] )[a-zA-Z0-9-]+/[a-zA-Z0-9-]+#\d+")
 
           # Unlink previously linked issues
-          CURRENT_LINKED_ISSUES=$(gh pr view $PR_NUMBER --json projectItems --jq '.projectItems[].content.number')
+          CURRENT_LINKED_ISSUES=$(gh pr view $PR_NUMBER --json projectItems --jq '.projectItems[].content.title')
           for ISSUE in $CURRENT_LINKED_ISSUES
           do
-            gh pr edit $PR_NUMBER --remove-project "Issue #$ISSUE"
-            echo "Unlinked issue #$ISSUE from PR #$PR_NUMBER"
+            gh pr edit $PR_NUMBER --remove-project "$ISSUE"
+            echo "Unlinked issue $ISSUE from PR #$PR_NUMBER"
           done
 
           # Link newly checked issues to PR
           for ISSUE in $CHECKED_ISSUES
           do
-            gh pr edit $PR_NUMBER --add-project "Issue #$ISSUE"
-            echo "Linked issue #$ISSUE to PR #$PR_NUMBER"
+            gh pr edit $PR_NUMBER --add-project "$ISSUE"
+            echo "Linked issue $ISSUE to PR #$PR_NUMBER"
           done
 
           # Update PR description to reflect linked issues
-          UPDATED_ISSUE_SECTION=$(echo "$ISSUE_SECTION" | sed "s/- \[x\] $ORG\/$REPO#\($CHECKED_ISSUES\)/- [x] $ORG\/$REPO#\1 (연결됨)/g")
+          UPDATED_ISSUE_SECTION=$(echo "$ISSUE_SECTION" | sed -E "s/- \[x\] ([a-zA-Z0-9-]+\/[a-zA-Z0-9-]+#[0-9]+)/- [x] \1 (연결됨)/g")
           UPDATED_PR_BODY="${PR_BODY//$ISSUE_SECTION/$UPDATED_ISSUE_SECTION}"
 
           gh pr edit $PR_NUMBER --body "$UPDATED_PR_BODY"


### PR DESCRIPTION
## 🤖 자동 생성된 PR 정보

### 📦 변경된 패키지
- mono-lab
### 📄 변경된 파일
- .github/workflows/update-pr-description.yml

### 📝 커밋 내역
- Revert fix: github action update 로직 개선
This reverts commit 0b738c55cdb1f962b00ecc1ce1f54d5262939651.
- fix: github action update 로직 개선
- Revert fix: 초기 템플릿으로 덮어씌우는 이슈 수정
This reverts commit 4c09f3c4226f815f9ba0043d725eda98989d7657.
- fix: 초기 템플릿으로 덮어씌우는 이슈 수정
새로운 변경사항을 유지하고 뒤에 추가하는 형식으로 변경
- fix: 체크한 리스트 찾지 못할 경우 문구 수정
- fix: 불필요한 echo 삭제 및 grep 실패할 경우 true로 수정
체크한 리스트가 없어도 실패하면 안됨
- fix: github action 붙임표 이슈로 인한 수정
- fix: commit msg - 이슈 수정
- fix: 디버깅 echo 수정 및 없을 경우 종료 로직 추가
- feat: github action link issue 디버깅 기능 추가
- chore: typo 삭제
- refactor: github action 불필요한 코드 삭제 및 개선
- Revert fix: github action pr 업데이트 로직 개선
This reverts commit 7ea6c7074da56dfcfb577f36f78380bfb294b176.
- fix: github action pr 업데이트 로직 개선
- fix: github action issue comment 제거 및 pr edit 추가
- fix: github action filter 조건 수정 및 이슈 할당 기준 수정
- fix: PR check 이슈 관리 수정
- fix: assigned 할당에서 link로 변경

### 관련 이슈
아래 목록에서 이 PR과 관련된 이슈를 선택해주세요. 선택한 이슈는 자동으로 PR과 연결됩니다:

- [ ] my-type-world-cup/my-type-world-cup-frontend#24 테스트 PR
- [ ] my-type-world-cup/my-type-world-cup-frontend#25 PR 테스트용 이슈 2
- [ ] my-type-world-cup/my-type-world-cup-frontend#26 테스트용 3